### PR TITLE
Fix NPE when using Advanced Dominion Wand without a mode set

### DIFF
--- a/src/main/java/com/github/jarva/arsadditions/common/item/AdvancedDominionWand.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/AdvancedDominionWand.java
@@ -60,8 +60,8 @@ public class AdvancedDominionWand extends Item {
         ItemStack stack = pPlayer.getItemInHand(pUsedHand);
 
         if (!pPlayer.isShiftKeyDown()) {
-            AdvancedDominionData data = AdvancedDominionData.fromItemStack(stack);
-            data = data.toggleMode().write(stack);
+            AdvancedDominionData data = AdvancedDominionData.fromItemStack(stack).toggleMode();
+            data.write(stack);
             PortUtil.sendMessageNoSpam(pPlayer, Component.translatable("chat.ars_additions.advanced_dominion_wand.mode", data.mode().getTranslatable()));
             return InteractionResultHolder.success(stack);
         }

--- a/src/main/java/com/github/jarva/arsadditions/common/item/data/AdvancedDominionData.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/data/AdvancedDominionData.java
@@ -14,6 +14,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -46,6 +47,7 @@ public record AdvancedDominionData(Optional<BlockPos> pos, Optional<ResourceKey<
         }
     }
 
+    @NotNull
     public static AdvancedDominionData fromItemStack(ItemStack stack) {
         return stack.getOrDefault(AddonDataComponentRegistry.ADVANCED_DOMINION_DATA.get(), new AdvancedDominionData(Optional.empty(), Optional.empty(), Optional.empty(), AdvancedDominionData.Mode.LOCK_FIRST));
     }
@@ -63,6 +65,11 @@ public record AdvancedDominionData(Optional<BlockPos> pos, Optional<ResourceKey<
         return new AdvancedDominionData(this.pos, this.level, this.entityId, this.mode == AdvancedDominionData.Mode.LOCK_FIRST ? AdvancedDominionData.Mode.LOCK_SECOND : AdvancedDominionData.Mode.LOCK_FIRST);
     }
 
+    /**
+     * @param stack The ItemStack to write the component to
+     * @return Returns the previously stored value of component or null if previously unset
+     */
+    @Nullable
     public AdvancedDominionData write(ItemStack stack) {
         return stack.set(AddonDataComponentRegistry.ADVANCED_DOMINION_DATA, this);
     }


### PR DESCRIPTION
On initial use, the AdvancedDominionWand does not have an AdvancedDominionData component set. This PR prevents performing a lookup on the null/missing component when it is initially toggled.

Fixes #33 