### PR TITLE
codestyle changes

### DIFF
--- a/src/main/java/com/github/jarva/arsadditions/common/item/curios/WarpIndex.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/curios/WarpIndex.java
@@ -7,9 +7,9 @@ import com.hollingsworth.arsnouveau.setup.registry.BlockRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.GlobalPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -33,12 +33,12 @@ public class WarpIndex extends Item {
 
     @Override
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltip, TooltipFlag flag) {
-        if(stack.has(AddonDataComponentRegistry.WARP_BIND_DATA)) {
-            WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
-            int x = data.pos().pos().getX();
-            int y = data.pos().pos().getY();
-            int z = data.pos().pos().getZ();
-            String dim = data.pos().dimension().location().toString();
+        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
+        if(data != null) {
+            int x = data.x();
+            int y = data.y();
+            int z = data.z();
+            String dim = data.getDimensionString();
             tooltip.add(Component.translatable("tooltip.ars_additions.warp_index.bound", x, y, z, dim));
         } else {
             tooltip.add(Component.translatable("chat.ars_additions.warp_index.unbound", Component.keybind("key.sneak"), Component.keybind("key.use"), LangUtil.storageLectern()));
@@ -61,7 +61,7 @@ public class WarpIndex extends Item {
         BlockState state = c.getLevel().getBlockState(pos);
         if(state.is(BlockRegistry.CRAFTING_LECTERN.get())) {
             ItemStack stack = c.getItemInHand();
-            stack.set(AddonDataComponentRegistry.WARP_BIND_DATA, new WarpBindData(new GlobalPos(c.getLevel().dimension(), pos)));
+            new WarpBindData(c.getLevel(), pos).write(stack);
             if(c.getPlayer() != null)
                 c.getPlayer().displayClientMessage(Component.translatable("chat.ars_additions.warp_index.bound", LangUtil.storageLectern()), true);
             return InteractionResult.SUCCESS;
@@ -70,7 +70,8 @@ public class WarpIndex extends Item {
     }
 
     public InteractionResult activateTerminal(Level worldIn, ItemStack stack, Player playerIn, InteractionHand handIn) {
-        if (!stack.has(AddonDataComponentRegistry.WARP_BIND_DATA)) {
+        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
+        if (data == null) {
             playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.unbound", Component.keybind("key.sneak"), Component.keybind("key.use"), LangUtil.storageLectern()), true);
             return InteractionResult.PASS;
         }
@@ -82,29 +83,35 @@ public class WarpIndex extends Item {
             return InteractionResult.CONSUME;
         }
 
-        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
-        int x = data.pos().pos().getX();
-        int y = data.pos().pos().getY();
-        int z = data.pos().pos().getZ();
-        ResourceKey<Level> dim = data.pos().dimension();
-        Level lecternWorld = worldIn.getServer().getLevel(dim);
-        if(lecternWorld.isLoaded(new BlockPos(x, y, z))) {
-            BlockHitResult lookingAt = new BlockHitResult(new Vec3(x, y, z), Direction.UP, new BlockPos(x, y, z), true);
-            BlockState state = lecternWorld.getBlockState(lookingAt.getBlockPos());
-            if(state.is(BlockRegistry.CRAFTING_LECTERN.get())) {
-                return state.useItemOn(stack, lecternWorld, playerIn, handIn, lookingAt).result();
-            } else {
-                playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.invalid_block", LangUtil.storageLectern()), true);
-            }
-        } else {
-            playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.out_of_range", LangUtil.storageLectern()), true);
+        MinecraftServer server = worldIn.getServer();
+        if (server == null) {
+            return InteractionResult.CONSUME;
         }
 
-        return InteractionResult.PASS;
+        ResourceKey<Level> dim = data.dimension();
+        BlockPos boundPos = data.blockPos();
+        Level lecternWorld = server.getLevel(dim);
+        // TODO: handle when stored level is missing from server with custom error
+        if (lecternWorld == null || !lecternWorld.isLoaded(boundPos)) {
+            playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.out_of_range", LangUtil.storageLectern()), true);
+            return InteractionResult.FAIL;
+        }
+
+        BlockState state = lecternWorld.getBlockState(boundPos);
+        if(!state.is(BlockRegistry.CRAFTING_LECTERN.get())) {
+            playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.invalid_block", LangUtil.storageLectern()), true);
+            return InteractionResult.FAIL;
+        }
+
+        BlockHitResult lookingAt = new BlockHitResult(Vec3.atLowerCornerOf(boundPos), Direction.UP, boundPos, true);
+        return state.useItemOn(stack, lecternWorld, playerIn, handIn, lookingAt).result();
+
     }
 
     public boolean canActivate(Level worldIn, ItemStack stack, Player playerIn, InteractionHand handIn) {
-        return stack.has(AddonDataComponentRegistry.WARP_BIND_DATA) && stack.get(AddonDataComponentRegistry.WARP_BIND_DATA).pos().dimension().equals(worldIn.dimension());
+        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
+        if (data == null) return false;
+        return data.isIn(worldIn.dimension());
     }
 
     public void open(Player sender, ItemStack t) {

--- a/src/main/java/com/github/jarva/arsadditions/common/item/curios/WarpIndex.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/curios/WarpIndex.java
@@ -25,6 +25,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public class WarpIndex extends Item {
     public WarpIndex() {
@@ -33,17 +34,11 @@ public class WarpIndex extends Item {
 
     @Override
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltip, TooltipFlag flag) {
-        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
-        if(data != null) {
-            int x = data.x();
-            int y = data.y();
-            int z = data.z();
-            String dim = data.getDimensionString();
-            tooltip.add(Component.translatable("tooltip.ars_additions.warp_index.bound", x, y, z, dim));
-        } else {
-            tooltip.add(Component.translatable("chat.ars_additions.warp_index.unbound", Component.keybind("key.sneak"), Component.keybind("key.use"), LangUtil.storageLectern()));
-        }
-
+        tooltip.add(
+            WarpBindData.fromItemStack(stack)
+                .map(data -> Component.translatable("tooltip.ars_additions.warp_index.bound", data.x(), data.y(), data.z(), data.getDimensionString()))
+                .orElse(Component.translatable("chat.ars_additions.warp_index.unbound", Component.keybind("key.sneak"), Component.keybind("key.use"), LangUtil.storageLectern()))
+        );
         tooltip.add(Component.translatable("tooltip.ars_additions.warp_index.keybind", Component.translatable("tooltip.ars_additions.warp_index.keybind.outline", Component.keybind("key.ars_additions.open_lectern")).withStyle(ChatFormatting.GREEN)));
     }
 
@@ -70,8 +65,8 @@ public class WarpIndex extends Item {
     }
 
     public InteractionResult activateTerminal(Level worldIn, ItemStack stack, Player playerIn, InteractionHand handIn) {
-        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
-        if (data == null) {
+        Optional<WarpBindData> dataOptional = WarpBindData.fromItemStack(stack);
+        if (dataOptional.isEmpty()) {
             playerIn.displayClientMessage(Component.translatable("chat.ars_additions.warp_index.unbound", Component.keybind("key.sneak"), Component.keybind("key.use"), LangUtil.storageLectern()), true);
             return InteractionResult.PASS;
         }
@@ -88,6 +83,7 @@ public class WarpIndex extends Item {
             return InteractionResult.CONSUME;
         }
 
+        WarpBindData data = dataOptional.get();
         ResourceKey<Level> dim = data.dimension();
         BlockPos boundPos = data.blockPos();
         Level lecternWorld = server.getLevel(dim);
@@ -109,9 +105,9 @@ public class WarpIndex extends Item {
     }
 
     public boolean canActivate(Level worldIn, ItemStack stack, Player playerIn, InteractionHand handIn) {
-        WarpBindData data = stack.get(AddonDataComponentRegistry.WARP_BIND_DATA);
-        if (data == null) return false;
-        return data.isIn(worldIn.dimension());
+        return WarpBindData.fromItemStack(stack)
+                .map(data->data.isIn(worldIn.dimension()))
+                .orElse(false);
     }
 
     public void open(Player sender, ItemStack t) {

--- a/src/main/java/com/github/jarva/arsadditions/common/item/data/HaversackData.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/data/HaversackData.java
@@ -1,6 +1,8 @@
 package com.github.jarva.arsadditions.common.item.data;
 
 import com.github.jarva.arsadditions.setup.registry.AddonDataComponentRegistry;
+import com.google.common.collect.ImmutableList;
+import com.hollingsworth.arsnouveau.api.item.inv.FilterSet;
 import com.hollingsworth.arsnouveau.api.item.inv.FilterableItemHandler;
 import com.hollingsworth.arsnouveau.api.util.InvUtil;
 import com.mojang.serialization.Codec;
@@ -53,15 +55,24 @@ public record HaversackData(GlobalPos pos, Direction side, Boolean active, List<
     }
 
     public HaversackData add(ItemStack stack) {
-        ArrayList<ItemStack> list = new ArrayList<>(items);
-        list.add(stack.copy());
+        List<ItemStack> list = ImmutableList.<ItemStack>builder()
+                .addAll(items)
+                .add(stack.copy())
+                .build();
         return new HaversackData(pos, side, active, list, loaded);
     }
 
+    /**
+     * Removes all items with the same Item type as the ItemStack provided
+     * @param stack ItemStack of the Item type to remove
+     * @return A new HaversackData component made from the new list
+     * @apiNote Does not compare component data. Will remove all ItemStacks
+     *          matching the Item returned by stack.getItem()
+     */
     public HaversackData remove(ItemStack stack) {
         ArrayList<ItemStack> list = new ArrayList<>(items);
         if (list.removeIf(s -> ItemStack.isSameItem(s, stack))) {
-            return new HaversackData(pos, side, active, list, loaded);
+            return new HaversackData(pos, side, active, ImmutableList.copyOf(list), loaded);
         }
         return this;
     }
@@ -87,6 +98,6 @@ public record HaversackData(GlobalPos pos, Direction side, Boolean active, List<
         BlockEntity be = level.getBlockEntity(pos.pos());
         if (be == null) return null;
 
-        return new FilterableItemHandler(level.getCapability(Capabilities.ItemHandler.BLOCK, pos.pos(), side), InvUtil.filtersOnTile(be));
+        return new FilterableItemHandler(level.getCapability(Capabilities.ItemHandler.BLOCK, pos.pos(), side), FilterSet.forPosition(level,pos.pos()));
     }
 }

--- a/src/main/java/com/github/jarva/arsadditions/common/item/data/WarpBindData.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/data/WarpBindData.java
@@ -1,10 +1,15 @@
 package com.github.jarva.arsadditions.common.item.data;
 
+import com.github.jarva.arsadditions.setup.registry.AddonDataComponentRegistry;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 
 public record WarpBindData(GlobalPos pos) {
     public static final Codec<WarpBindData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
@@ -14,4 +19,40 @@ public record WarpBindData(GlobalPos pos) {
     public static final StreamCodec<RegistryFriendlyByteBuf, WarpBindData> STREAM_CODEC = StreamCodec.composite(
             GlobalPos.STREAM_CODEC, WarpBindData::pos, WarpBindData::new
     );
+
+    public WarpBindData(Level level, BlockPos pos) {
+        this(new GlobalPos(level.dimension(), pos));
+    }
+
+    public boolean isIn(ResourceKey<Level> dimension) {
+        return this.pos().dimension().equals(dimension);
+    }
+
+    public String getDimensionString() {
+        return this.pos().dimension().location().toString();
+    }
+
+    public int x() {
+        return this.pos().pos().getX();
+    }
+
+    public int y() {
+        return this.pos().pos().getY();
+    }
+
+    public int z() {
+        return this.pos().pos().getZ();
+    }
+
+    public BlockPos blockPos() {
+        return this.pos().pos();
+    }
+
+    public ResourceKey<Level> dimension() {
+        return this.pos().dimension();
+    }
+
+    public WarpBindData write(ItemStack stack) {
+        return stack.set(AddonDataComponentRegistry.WARP_BIND_DATA, this);
+    }
 }

--- a/src/main/java/com/github/jarva/arsadditions/common/item/data/WarpBindData.java
+++ b/src/main/java/com/github/jarva/arsadditions/common/item/data/WarpBindData.java
@@ -11,6 +11,8 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import java.util.Optional;
+
 public record WarpBindData(GlobalPos pos) {
     public static final Codec<WarpBindData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             GlobalPos.CODEC.fieldOf("pos").forGetter(WarpBindData::pos)
@@ -22,6 +24,10 @@ public record WarpBindData(GlobalPos pos) {
 
     public WarpBindData(Level level, BlockPos pos) {
         this(new GlobalPos(level.dimension(), pos));
+    }
+
+    public static Optional<WarpBindData> fromItemStack(ItemStack stack) {
+        return Optional.ofNullable(stack.get(AddonDataComponentRegistry.WARP_BIND_DATA));
     }
 
     public boolean isIn(ResourceKey<Level> dimension) {


### PR DESCRIPTION
Changes HaversackData to use immutable lists to prevent accidental mutability from ArrayList
moves most implementation details for WarpBindData into the WarpBindData class and uses fromItemStack method for retrieval and write method for storage
Uses Optional instead of null checks for WarpBindData retrieval, matching HaversackData, since there is no default value